### PR TITLE
Add CLI --output and --force-all options & improve nextflow config defaults

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9"]
+        python-version: ["3.11"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,14 +44,9 @@ jobs:
           python -m pip install --upgrade pip setuptools
           pip install .[dev,test]
           python -c 'from sinclair.src.util import chmod_bins_exec; chmod_bins_exec()'
-      - name: Check out-of-the-box CLI script
+      - name: pytest
         run: |
-          bash bin/sinclair --help
-      - name: Check CLI basics
-        run: |
-          which sinclair
-          sinclair --version
-          sinclair --citation
+          pytest tests
       - name: Stub run
         run: |
           mkdir tmp && cd tmp

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,7 @@ jobs:
             -profile ci_stub,docker,test \
             -entry GEX
       - name: "Upload Artifact"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always() # run even if previous steps fail
         with:
           name: nextflow-log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,15 @@
 ## SINCLAIR development version
 
-- Overhaul the CLI to use python rather than bash, which introduces breaking changes (#61, @kelly-sovacool).
-  - Create a script (`bin/sinclair`) to provide an interface to the CLI that works out-of-the-box without the need to install the python package with pip. (#80, @kelly-sovacool)
+- New features
+  - Allows users to determine what variables to regress out. (#55, @slsevilla)
+  - Overhaul the CLI to use python rather than bash, which introduces breaking changes (#61, @kelly-sovacool).
+    - Create a script (`bin/sinclair`) to provide an interface to the CLI that works out-of-the-box without the need to install the python package with pip. (#80, @kelly-sovacool)
+  - Use `nextflow run -resume` by default, or turn it off with `sinclair run --forceall`. (#110, @kelly-sovacool)
+  - Add `--output` argument for `sinclair init` and `sinclair run`. (#110, @kelly-sovacool)
+    - If not provided, commands are run in the current working directory.
+    - This is equivalent to the nextflow `$launchDir` constant.
+  - Set the `publish_dir_mode` nextflow option to `link` by default. (#110, @kelly-sovacool)
+  - Set the `process.cache` nextflow option to `deep` by default rather than lenient on biowulf. (#110, @kelly-sovacool)
 - Bug fixes
   - Fix biowulf module syntax in `conf/modules.config`. (#81, @epehrsson)
   - Fix filtering thresholds and use filtered object for downstream steps in `SEURAT_PROCESS`. (#81, @epehrsson)
@@ -15,8 +23,6 @@
   - Set all default parameters in `nextflow.config`. (#85, @epehrsson)
     - Previously, some parameters were set in `conf/process_params.config`, but we found this confusing, so we consolidated them to the main `nextflow.config` file.
   - Allow sample IDs to contain hyphens. (#94, @wong-nw)
-- New features
-  - Allows users to determine what variables to regress out. (#55, @slsevilla)
 - Documentation improvements
   - The docs website now has a drop-down menu to switch between different versions. (#103, @kelly-sovacool)
   - Fix broken image link. (#108, @wong-nw)

--- a/README.md
+++ b/README.md
@@ -36,27 +36,26 @@ Example workflow
 
 ```
 # 1) run initialization
-mkdir -p /path/to/output/dir
-cd /path/to/output/dir
-sinclair init
+# --output is optional and defaults to your current working directory.
+sinclair init --output /path/to/output/dir
 
 # 2) update the config files as needed
 ## can change whether cellranger is deployed, species, names of manifest files (default locations listed below)
-/path/to/output/dirnextflow.config
+/path/to/output/dir/nextflow.config
 /path/to/output/dir/assets/contrast_manifest.csv /path/to/output/dir/assets/input_manifest.csv
 
 # 3) deploy the pipeline
 ## A) STUBRUN
-sinclair run -stub -entry GEX
+sinclair run -stub -entry GEX --output /path/to/output/dir
 
 ## B) local run
-sinclair run -entry GEX
+sinclair run -entry GEX --output /path/to/output/dir
 
 ## C) submit to slurm
-sinclair run --mode slurm -entry GEX
+sinclair run --mode slurm -entry GEX --output /path/to/output/dir
 
 # 4) OPTIONAL resume
-sinclair run --mode slurm -entry GEX -resume
+sinclair run --mode slurm -entry GEX -resume --output /path/to/output/dir
 ```
 
 ### 4. Detailed Documentation

--- a/conf/biowulf.config
+++ b/conf/biowulf.config
@@ -30,5 +30,5 @@ process.clusterOptions = ' --gres=lscratch:200 '
 process.scratch = '/lscratch/$SLURM_JOB_ID'
 process.stageInMode = 'symlink'
 process.stageOutMode = 'rsync'
-// for running pipeline on group sharing data directory, this can avoid inconsistent files timestamps
-process.cache = 'lenient'
+// https://www.nextflow.io/docs/latest/reference/process.html#cache
+process.cache = 'deep'

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -1,10 +1,12 @@
 process {
 
     publishDir = [
-        path: { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" },
-        mode: 'copy',
+        path: { task.label ? "${params.outdir}/${task.label.findAll { !it.startsWith('process_') & !it.startsWith('error_') }.join('/')}/${task.process.tokenize(':')[-1].toLowerCase()}" : "${params.outdir}/${task.process.tokenize(':')[-1].toLowerCase()}" },
+        mode: params.publish_dir_mode,
         saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
     ]
+
+    errorStrategy = 'finish'
 
     withName: SAMPLESHEET_CHECK {
         publishDir = [

--- a/nextflow.config
+++ b/nextflow.config
@@ -55,6 +55,7 @@ params {
     script_liger                = "${projectDir}/bin/batch_correction_liger.Rmd"
     script_bc_integration       = "${projectDir}/bin/batch_correction_integration.Rmd"
 
+    publish_dir_mode = 'link'
     // Max resource options
     max_memory                 = '128.GB'
     max_cpus                   = 48

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ classifiers = [
 requires-python = ">=3.8"
 dependencies = [
     "pyyaml >= 6.0",
-    "ccbr_tools@git+https://github.com/CCBR/Tools@v0.1",
+    "ccbr_tools@git+https://github.com/CCBR/Tools@v0.2",
     "Click >= 8.1.3",
     "cffconvert >= 2.0.0"
 ]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,91 @@
+import os.path
+import pathlib
+import pytest
+import subprocess
+import tempfile
+from ccbr_tools.shell import shell_run
+
+
+def test_help():
+    output = subprocess.run(
+        "./bin/sinclair --help", capture_output=True, shell=True, text=True
+    ).stdout
+    assert "Usage: sinclair [OPTIONS]" in output
+
+
+def test_version():
+    output = subprocess.run(
+        "./bin/sinclair --version", capture_output=True, shell=True, text=True
+    ).stdout
+    assert "sinclair, version" in output
+
+
+def test_citation():
+    output = subprocess.run(
+        "./bin/sinclair --citation", capture_output=True, shell=True, text=True
+    ).stdout
+    assert "title = {SINCLAIR" in output
+
+
+def test_preview():
+    output = subprocess.run(
+        "./bin/sinclair run -entry GEX -preview -profile ci_stub",
+        capture_output=True,
+        shell=True,
+        text=True,
+        check=True,
+    ).stdout
+    cmd_line = {
+        l.split(":")[0].strip(): l.split(":")[1].strip()
+        for l in output.split("\n")
+        if ":" in l
+    }["cmd line"]
+    assert "-preview" in cmd_line and "-resume" in cmd_line
+
+
+def test_forceall():
+    output = subprocess.run(
+        "./bin/sinclair run -entry GEX --forceall -preview -profile ci_stub",
+        capture_output=True,
+        shell=True,
+        text=True,
+        check=True,
+    ).stdout
+    cmd_line = {
+        l.split(":")[0].strip(): l.split(":")[1].strip()
+        for l in output.split("\n")
+        if ":" in l
+    }["cmd line"]
+    assert "-preview" in cmd_line and "-resume" not in cmd_line
+
+
+def test_init():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        output = shell_run(f"./bin/sinclair init --output {tmp_dir}")
+        outdir = pathlib.Path(tmp_dir)
+        assertions = [(outdir / "nextflow.config").exists(), (outdir / "log").exists()]
+    assert all(assertions)
+
+
+def test_init_default():
+    cwd = os.getcwd()
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        os.chdir(tmp_dir)
+        output = shell_run(f"{cwd}/bin/sinclair init")
+        outdir = pathlib.Path(tmp_dir)
+        assertions = [(outdir / "nextflow.config").exists(), (outdir / "log").exists()]
+
+    os.chdir(cwd)
+    assert all(assertions)
+
+
+def test_run_no_init():
+    with pytest.raises(Exception) as exc_info:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            output = shell_run(
+                f"./bin/sinclair run -entry GEX --output {tmp_dir}",
+                check=True,
+                capture_output=True,
+            )
+            assertions = ["Hint: you must initialize the output directory" in output]
+            assert all(assertions)


### PR DESCRIPTION
## Changes

### sinclair CLI

- New `--output` argument for `init` & `run` if you would like to run the pipeline from a directory other than your current working directory.
- `-resume` is now used by default and can be turned off with `--forceall`.
- Set up pytest for basic CLI checks.

### nextflow config

- Set `process.cache` to `deep` for biowulf.
- Set `publish_dir_mode` to `link`.
- Set `errorStrategy` to `finish`.

## Issues

resolves #106 

## PR Checklist

(~Strikethrough~ any points that are not applicable.)

- [x] This comment contains a description of changes with justifications, with any relevant issues linked.
- [x] Write tests using [`nf-test`](https://www.nf-test.com/) for any new features, bug fixes, or other code changes.
- [x] Update docs if there are any API changes.
- ~[ ] If a new nextflow process is implemented, define the process `container` and `stub`.~
- [x] Update `CHANGELOG.md` with a short description of any user-facing changes and reference the PR number. Guidelines: https://keepachangelog.com/en/1.1.0/
