### PR TITLE
chore: set biowulf-specific path in biowulf config profile

### DIFF
--- a/conf/biowulf.config
+++ b/conf/biowulf.config
@@ -10,6 +10,7 @@ params {
     igenomes_base = '/fdb/igenomes/'
 
     // CCBR shared resource paths
+    genome_dir = "/data/CCBR_Pipeliner/db/PipeDB/cellranger_ref/${params.species}"
     index_dir = '/data/CCBR_Pipeliner/db/PipeDB/Indices'
     fastq_screen {
         conf = "assets/fastq_screen_biowulf.conf"

--- a/conf/ci_stub.config
+++ b/conf/ci_stub.config
@@ -7,4 +7,5 @@ params {
     max_time   = '6.h'
 
     publish_dir_mode = "copy"
+    genome_dir = ''
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -39,7 +39,7 @@ params {
     tracedir                   = "${params.outdir}/pipeline_info"
 
     // References
-    genome_dir                 ="/data/CCBR_Pipeliner/db/PipeDB/cellranger_ref/${params.species}"
+    genome_dir                 = null // this is overridden by conf/biowulf.config
 
     // R Config
     Rpkg                        = "${projectDir}/conf/Rpack.config"


### PR DESCRIPTION
## Changes

the default `nextflow.config` should not contain any biowulf-specific paths. these are instead set in `conf/biowulf.config`

## Issues

fixes #97

## PR Checklist

(~Strikethrough~ any points that are not applicable.)

- [x] This comment contains a description of changes with justifications, with any relevant issues linked.
- ~[ ] Write tests using [`nf-test`](https://www.nf-test.com/) for any new features, bug fixes, or other code changes.~
- ~[ ] Update docs if there are any API changes.~
- ~[ ] If a new nextflow process is implemented, define the process `container` and `stub`.~
- ~[ ] Update `CHANGELOG.md` with a short description of any user-facing changes and reference the PR number. Guidelines: https://keepachangelog.com/en/1.1.0/~
