### PR TITLE
feat: print nxf preview before running actual nxf command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
   - This is equivalent to the nextflow `$launchDir` constant.
 - Set the `publish_dir_mode` nextflow option to `link` by default. (#110, @kelly-sovacool)
 - Set the `process.cache` nextflow option to `deep` by default rather than lenient on biowulf. (#110, @kelly-sovacool)
+- The nextflow preview is printed before launching the actual run. (#117, @kelly-sovacool)
 
 ### Bug fixes
 

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -107,7 +107,6 @@ def run(main_path, output, _mode, force_all, **kwargs):
                 f"Path to the sinclair main.nf file not found: {main_path}"
             )
     output_dir = output if isinstance(output, pathlib.Path) else pathlib.Path(output)
-    msg_box("output directory", errmsg=str(output_dir))
     if not output_dir.is_dir() or not (output_dir / "nextflow.config").exists():
         raise FileNotFoundError(
             f"output directory not initialized: {output_dir}. Hint: you must initialize the output directory with `sinclair init --output {output_dir}`"

--- a/src/util.py
+++ b/src/util.py
@@ -177,12 +177,13 @@ def run_nextflow(
     # add any additional Nextflow commands
     args_dict = dict()
     prev_arg = ""
-    for arg in nextflow_args:
-        if arg.startswith("-"):
-            args_dict[arg] = ""
-        elif prev_arg.startswith("-"):
-            args_dict[prev_arg] = arg
-        prev_arg = arg
+    if nextflow_args:
+        for arg in nextflow_args:
+            if arg.startswith("-"):
+                args_dict[arg] = ""
+            elif prev_arg.startswith("-"):
+                args_dict[prev_arg] = arg
+            prev_arg = arg
     # make sure profile matches biowulf or frce
     profiles = (
         set(args_dict["-profile"].split(","))
@@ -205,10 +206,14 @@ def run_nextflow(
         args_dict["-resume"] = ""
 
     nextflow_command += list(f"{k} {v}" for k, v in args_dict.items())
-
-    # Print nextflow command
     nextflow_command = " ".join(str(nf) for nf in nextflow_command)
+    # Print nextflow command
     msg_box("Nextflow command", errmsg=nextflow_command)
+    # Print a preview before launching the actual run
+    if "-preview" not in args_dict.keys():
+        preview_command = nextflow_command + " -preview"
+        msg_box("Pipeline Preview", errmsg=preview_command)
+        subprocess.run(preview_command, shell=True, check=True)
 
     if mode == "slurm":
         slurm_filename = "submit_slurm.sh"

--- a/src/util.py
+++ b/src/util.py
@@ -169,7 +169,6 @@ def run_nextflow(
     nextflow_args=None,
 ):
     """Run a Nextflow workflow"""
-    nextflow_command = ["nextflow", "run", nextfile_path]
 
     hpc = get_hpc()
     if mode == "slurm" and not hpc:
@@ -205,15 +204,17 @@ def run_nextflow(
     elif not force_all and "-resume" not in args_dict.keys():
         args_dict["-resume"] = ""
 
-    nextflow_command += list(f"{k} {v}" for k, v in args_dict.items())
-    nextflow_command = " ".join(str(nf) for nf in nextflow_command)
-    # Print nextflow command
-    msg_box("Nextflow command", errmsg=nextflow_command)
+    nextflow_command = ["nextflow", "run", nextfile_path] + [
+        f"{k} {v}" for k, v in args_dict.items()
+    ]
+    nextflow_command = " ".join(nextflow_command)
     # Print a preview before launching the actual run
     if "-preview" not in args_dict.keys():
         preview_command = nextflow_command + " -preview"
         msg_box("Pipeline Preview", errmsg=preview_command)
         subprocess.run(preview_command, shell=True, check=True)
+    # Print nextflow command
+    msg_box("Nextflow command", errmsg=nextflow_command)
 
     if mode == "slurm":
         slurm_filename = "submit_slurm.sh"


### PR DESCRIPTION
## Changes

if `-preview` is not part of the nextflow command, first run the command with `-preview` before launching the actual run. This prints the nextflow `log.info` block and allows the user to see which processes may run.

### Example

```sh
./bin/sinclair run -profile test -entry GEX --mode slurm --output /data/sovacoolkl/sinclair_test
```
```
[2025:03:27 10:58:47] --------------------
[2025:03:27 10:58:47] | Pipeline Preview |
[2025:03:27 10:58:47] --------------------

nextflow run /gpfs/gsfs10/users/CCBR_Pipeliner/Pipelines/SINCLAIR/sinclar-dev-sovacool/main.nf -profile biowulf,slurm,test -entry GEX -resume  -preview
Nextflow 24.10.5 is available - Please consider updating your version to it

 N E X T F L O W   ~  version 24.10.0

WARN: It appears you have never run this project before -- Option `-resume` is ignored
Launching `/gpfs/gsfs10/users/CCBR_Pipeliner/Pipelines/SINCLAIR/sinclar-dev-sovacool/main.nf` [intergalactic_gates] DSL2 - revision: 2250085eb7

S I N C L A I R   P I P E L I N E
===================================
NF version   : 24.10.0
runName      : intergalactic_gates
username     : sovacoolkl
configs      : [/gpfs/gsfs10/users/CCBR_Pipeliner/Pipelines/SINCLAIR/sinclar-dev-sovacool/nextflow.config, /gpfs/gsfs12/users/sovacoolkl/sinclair_test/nextflow.config]
profile      : biowulf,slurm,test
cmd line     : nextflow run /gpfs/gsfs10/users/CCBR_Pipeliner/Pipelines/SINCLAIR/sinclar-dev-sovacool/main.nf -profile biowulf,slurm,test -entry GEX -resume -preview
start time   : 2025-03-27T10:58:53.082391379-04:00
projectDir   : /gpfs/gsfs10/users/CCBR_Pipeliner/Pipelines/SINCLAIR/sinclar-dev-sovacool
launchDir    : /gpfs/gsfs12/users/sovacoolkl/sinclair_test
workDir      : /gpfs/gsfs12/users/sovacoolkl/sinclair_test/work
homeDir      : /home/sovacoolkl
outDir       : /gpfs/gsfs10/users/CCBR_Pipeliner/Pipelines/SINCLAIR/sinclar-dev-sovacool/results/tests

[-        ] GEX:PREPROCESS_EXQC:INPUT_CHECK_GEX:SAMPLESHEET_CHECK -
[-        ] GEX:PREPROCESS_EXQC:CELLRANGER_COUNT                  -
[-        ] GEX:GEX_EXQC:SEURAT_PREPROCESS                        -
[-        ] GEX:GEX_EXQC:SEURAT_MERGE                             -
[-        ] GEX:GEX_EXQC:BATCH_CORRECT_HARMONY                    -
[-        ] GEX:GEX_EXQC:BATCH_CORRECT_RPCA                       -
[-        ] GEX:GEX_EXQC:BATCH_CORRECT_CCA                        -
[-        ] GEX:GEX_EXQC:BATCH_CORRECT_LIGER                      -
[-        ] GEX:GEX_EXQC:BATCH_CORRECT_INTEGRATION                -
WARN: There's no process matching config selector: BATCH_CORRECT_SCVI -- Did you mean: BATCH_CORRECT_CCA?

[2025:03:27 10:58:56] --------------------
[2025:03:27 10:58:56] | Nextflow command |
[2025:03:27 10:58:56] --------------------

nextflow run /gpfs/gsfs10/users/CCBR_Pipeliner/Pipelines/SINCLAIR/sinclar-dev-sovacool/main.nf -profile biowulf,slurm,test -entry GEX -resume 
[2025:03:27 10:58:56] -------------------
[2025:03:27 10:58:56] | Slurm batch job |
[2025:03:27 10:58:56] -------------------

sbatch submit_slurm.sh
52023981
```

## Issues

resolves #116

## PR Checklist

(~Strikethrough~ any points that are not applicable.)

- [x] This comment contains a description of changes with justifications, with any relevant issues linked.
- ~[ ] Write tests using [`nf-test`](https://www.nf-test.com/) for any new features, bug fixes, or other code changes.~
- ~[ ] Update docs if there are any API changes.~ _Nathan is updating the docs_
- ~[ ] If a new nextflow process is implemented, define the process `container` and `stub`.~
- [x] Update `CHANGELOG.md` with a short description of any user-facing changes and reference the PR number. Guidelines: https://keepachangelog.com/en/1.1.0/
