### PR TITLE
fix: set vars_to_regress to null by default

### DIFF
--- a/bin/batch_correction_cca.Rmd
+++ b/bin/batch_correction_cca.Rmd
@@ -11,7 +11,7 @@ params:
   mergedObj: "/data/sevillas2/sinclair/dev/results/seurat/merge/group1-group2_seurat_merged.rds"
   resolution_list: "0.1,0.2,0.3,0.5,0.6,0.8,1"
   npcs: 50
-  vars_to_regress: "None"
+  vars_to_regress: NULL
   Rlib_dir: "/data/CCBR_Pipeliner/db/PipeDB/Rlibrary_4.3_scRNA_RHEL8/"
   Rpkg_config: "/data/CCBR_Pipeliner/Pipelines/SINCLAIR/dev/conf/Rpack.config"
   scRNA_functions: "/data/CCBR_Pipeliner/Pipelines/SINCLAIR/dev/bin/scRNA_functions.R"
@@ -26,8 +26,12 @@ gid <- params$gid
 mergedObj <- params$mergedObj
 resolution <- as.numeric(strsplit(params$resolution_list, ",")[[1]])
 npcs <- as.numeric(params$npcs)
-vars_to_regress_list <- strsplit(gsub(" ", "", params$vars_to_regress), ",")[[1]]
-
+vars_to_regress <- params$vars_to_regress
+vars_to_regress_list <- if (is.null(vars_to_regress) || toupper(vars_to_regress) == "NULL") {
+  NULL
+} else {
+  unlist(strsplit(gsub(" ", "", vars_to_regress), ","))
+}
 Rlib_dir <- params$Rlib_dir
 Rpkg_config <- params$Rpkg_config
 testing <- params$testing

--- a/bin/batch_correction_harmony.Rmd
+++ b/bin/batch_correction_harmony.Rmd
@@ -11,7 +11,7 @@ params:
   species: "hg38"
   resolution_list: "0.1,0.2,0.3,0.5,0.6,0.8,1"
   npcs: "50"
-  vars_to_regress: "None"
+  vars_to_regress: NULL
   Rlib_dir: "/data/CCBR_Pipeliner/db/PipeDB/Rlibrary_4.3_scRNA_RHEL8/"
   Rpkg_config: "/data/CCBR_Pipeliner/Pipelines/SINCLAIR/dev/conf/Rpack.config"
   scRNA_functions: "/data/CCBR_Pipeliner/Pipelines/SINCLAIR/dev/bin/scRNA_functions.R"
@@ -25,8 +25,12 @@ gid <- params$gid
 mergedObj <- params$mergedObj
 resolution <- as.numeric(strsplit(params$resolution_list, ",")[[1]])
 npcs <- as.numeric(params$npcs)
-vars_to_regress_list <- strsplit(gsub(" ", "", params$vars_to_regress), ",")[[1]]
-
+vars_to_regress <- params$vars_to_regress
+vars_to_regress_list <- if (is.null(vars_to_regress) || toupper(vars_to_regress) == "NULL") {
+  NULL
+} else {
+  unlist(strsplit(gsub(" ", "", vars_to_regress), ","))
+}
 Rlib_dir <- params$Rlib_dir
 Rpkg_config <- params$Rpkg_config
 scRNA_functions <- params$scRNA_functions

--- a/bin/batch_correction_liger.Rmd
+++ b/bin/batch_correction_liger.Rmd
@@ -11,7 +11,7 @@ params:
   mergedObj: "/data/sevillas2/sinclair/dev/results/seurat/merge/group1-group2_seurat_merged.rds"
   resolution_list: "0.1,0.2,0.3,0.5,0.6,0.8,1"
   npcs: 50
-  vars_to_regress: "None"
+  vars_to_regress: NULL
   Rlib_dir: "/data/CCBR_Pipeliner/db/PipeDB/Rlibrary_4.3_scRNA_RHEL8/"
   Rpkg_config: "/data/CCBR_Pipeliner/Pipelines/SINCLAIR/dev/conf/Rpack.config"
   scRNA_functions: "/data/CCBR_Pipeliner/Pipelines/SINCLAIR/dev/bin/scRNA_functions.R"
@@ -26,8 +26,12 @@ gid <- params$gid
 mergedObj <- params$mergedObj
 resolution <- as.numeric(strsplit(params$resolution_list, ",")[[1]])
 npcs <- as.numeric(params$npcs)
-vars_to_regress_list <- strsplit(gsub(" ", "", params$vars_to_regress), ",")[[1]]
-
+vars_to_regress <- params$vars_to_regress
+vars_to_regress_list <- if (is.null(vars_to_regress) || toupper(vars_to_regress) == "NULL") {
+  NULL
+} else {
+  unlist(strsplit(gsub(" ", "", vars_to_regress), ","))
+}
 Rlib_dir <- params$Rlib_dir
 Rpkg_config <- params$Rpkg_config
 testing <- params$testing

--- a/bin/batch_correction_rpca.Rmd
+++ b/bin/batch_correction_rpca.Rmd
@@ -11,7 +11,7 @@ params:
   mergedObj: "/data/sevillas2/sinclair/dev/results/seurat/merge/group1-group2_seurat_merged.rds"
   resolution_list: "0.1,0.2,0.3,0.5,0.6,0.8,1"
   npcs: "50"
-  vars_to_regress: "None"
+  vars_to_regress: NULL
   Rlib_dir: "/data/CCBR_Pipeliner/db/PipeDB/Rlibrary_4.3_scRNA_RHEL8/"
   Rpkg_config: "/data/CCBR_Pipeliner/Pipelines/SINCLAIR/dev/conf/Rpack.config"
   scRNA_functions: "/data/CCBR_Pipeliner/Pipelines/SINCLAIR/dev/bin/scRNA_functions.R"
@@ -25,8 +25,12 @@ gid <- params$gid
 mergedObj <- params$mergedObj
 resolution <- as.numeric(strsplit(params$resolution_list, ",")[[1]])
 npcs <- as.numeric(params$npcs)
-vars_to_regress_list <- strsplit(gsub(" ", "", params$vars_to_regress), ",")[[1]]
-
+vars_to_regress <- params$vars_to_regress
+vars_to_regress_list <- if (is.null(vars_to_regress) || toupper(vars_to_regress) == "NULL") {
+  NULL
+} else {
+  unlist(strsplit(gsub(" ", "", vars_to_regress), ","))
+}
 Rlib_dir <- params$Rlib_dir
 Rpkg_config <- params$Rpkg_config
 scRNA_functions <- params$scRNA_functions

--- a/bin/batch_correction_scvi.Rmd
+++ b/bin/batch_correction_scvi.Rmd
@@ -11,7 +11,7 @@ params:
   mergedObj: "/data/sevillas2/sinclair/dev/results/seurat/merge/group1-group2_seurat_merged.rds"
   resolution_list: "0.1,0.2,0.3,0.5,0.6,0.8,1"
   npcs: "50"
-  vars_to_regress: "None"
+  vars_to_regress: NULL
   python_path: "/gpfs/gsfs10/users/CCBR_Pipeliner/db/PipeDB/Conda/envs/scvi-env/bin"
   conda_path: "/gpfs/gsfs10/users/CCBR_Pipeliner/db/PipeDB/Conda/envs/scvi-env"
   Rlib_dir: "/data/CCBR_Pipeliner/db/PipeDB/Rlibrary_4.3_scRNA_RHEL8/"
@@ -27,8 +27,12 @@ gid <- params$gid
 mergedObj <- params$mergedObj
 resolution <- as.numeric(strsplit(params$resolution_list, ",")[[1]])
 npcs <- as.numeric(params$npcs)
-vars_to_regress_list <- strsplit(gsub(" ", "", params$vars_to_regress), ",")[[1]]
-
+vars_to_regress <- params$vars_to_regress
+vars_to_regress_list <- if (is.null(vars_to_regress) || toupper(vars_to_regress) == "NULL") {
+  NULL
+} else {
+  unlist(strsplit(gsub(" ", "", vars_to_regress), ","))
+}
 python_path <- params$python_path
 conda_path <- params$conda_path
 Rlib_dir <- params$Rlib_dir

--- a/bin/scRNA_functions.R
+++ b/bin/scRNA_functions.R
@@ -38,7 +38,7 @@ SEURAT_CLUSTERING <- function(so_in, npcs_in) {
     npcs = 50
   )
   so <- FindNeighbors(so, dims = 1:npcs_in)
-  so <- FindClusters(so, resolution = 0.8, algorithm = 3, verbose=TRUE)
+  so <- FindClusters(so, resolution = 0.8, algorithm = 3, verbose = TRUE)
   so <- RunUMAP(so, dims = 1:npcs_in, n.components = 3)
   return(so)
 }
@@ -170,7 +170,7 @@ RUN_SINGLEr_AVERAGE <- function(obj, refFile, fineORmain) {
   return(annotVect)
 }
 
-MAIN_BATCH_CORRECTION <- function(so_in, npcs, species, resolution_list, method_in, reduction_in, v_list, conda_env = "") {
+MAIN_BATCH_CORRECTION <- function(so_in, npcs, species, resolution_list, method_in, reduction_in, v_list = NULL, conda_env = "") {
   # set assay to RNA to avoid double transform/norm
   DefaultAssay(so_in) <- "RNA"
 
@@ -203,12 +203,8 @@ MAIN_BATCH_CORRECTION <- function(so_in, npcs, species, resolution_list, method_
   } else {
     print("--running SCT")
 
-    # use variables to regress, if provided by user
-    if (length(v_list) == 0 | v_list=="None") {
-      so_transform <- SCTransform(so_in)
-    } else {
-      so_transform <- SCTransform(so_in, vars.to.regress = v_list)
-    }
+    # vars.to.regress is NULL by default
+    so_transform <- SCTransform(so_in, vars.to.regress = v_list)
 
     # runPCA
     so_pca <- RunPCA(so_transform)

--- a/bin/seurat_merge.Rmd
+++ b/bin/seurat_merge.Rmd
@@ -8,7 +8,7 @@ editor_options:
 params:
   species: "hg38"
   npcs: 50
-  vars_to_regress: "None"
+  vars_to_regress: NULL
   samplesheet: "/data/CCBR_Pipeliner/Pipelines/SINCLAIR/dev/assets/input_manifest_cellranger.csv"
   rdsFiles: "/data/sevillas2/sinclair/dev/results/seurat/preprocess/sample2_seurat_preprocess.rds /data/sevillas2/sinclair/dev/results/seurat/preprocess/sample4_seurat_preprocess.rds"
   gid: "group1-group2"
@@ -21,7 +21,12 @@ params:
 ```{r, prep_args,  message=FALSE, include=FALSE}
 # set up params
 species <- params$species
-vars_to_regress_list <- strsplit(gsub(" ", "", params$vars_to_regress), ",")[[1]]
+vars_to_regress <- params$vars_to_regress
+vars_to_regress_list <- if (is.null(vars_to_regress) || toupper(vars_to_regress) == "NULL") {
+  NULL
+} else {
+  unlist(strsplit(gsub(" ", "", vars_to_regress), ","))
+}
 rds_files <- strsplit(params$rdsFiles, " ")[[1]]
 gid <- params$gid
 samplesheet <- params$samplesheet
@@ -128,12 +133,9 @@ VariableFeatures(combinedObj.integratedRNA) <- selectFeatures
 ```
 
 ```{r mergedObjDims, message=FALSE, echo=FALSE}
-# use variables to regress, if provided by user
-if (length(vars_to_regress_list) == 0 | vars_to_regress_list=="None") {
-  so_merged <- SCTransform(combinedObj.integratedRNA, assay = "RNA")
-} else {
-  so_merged <- SCTransform(combinedObj.integratedRNA, vars.to.regress = vars_to_regress_list, assay = "RNA")
-}
+# vars.to.regress is NULL by default
+so_merged <- SCTransform(combinedObj.integratedRNA, vars.to.regress = vars_to_regress_list, assay = "RNA")
+
 # add reduction methods to the mergedObj for plotting
 so_merged <- RunPCA(so_merged, npcs = 50, verbose = F)
 so_merged <- RunTSNE(so_merged,

--- a/docs/params.md
+++ b/docs/params.md
@@ -18,7 +18,7 @@ Define where the pipeline should find input data and save output data.
 | -------------------- | --------------------------------------------------------------------------------------- | --------- | ------------------------- | -------- | ------ |
 | `species`            |                                                                                         | `string`  | hg19                      |          |        |
 | `run_cellranger`     | whether to run cellranger                                                               | `string`  | Y                         |          |        |
-| `vars_to_regress`    |                                                                                         | `string`  | percent.mt,nFeature_RNA   |          |        |
+| `vars_to_regress`    |                                                                                         | `string`  |                           |          |        |
 | `qc_filtering`       |                                                                                         | `string`  | manual                    |          |        |
 | `nCount_RNA_max`     |                                                                                         | `integer` | 500000                    |          |        |
 | `nCount_RNA_min`     |                                                                                         | `integer` | 1000                      |          |        |

--- a/nextflow.config
+++ b/nextflow.config
@@ -13,7 +13,7 @@ params {
     outdir                      = "${launchDir}/output"
     species                     = "hg38" // other options are "hg19", "GRCh38" (which is an alternate name for hg38), "mm10", "GRCm39"
     run_cellranger              = "Y"
-    vars_to_regress             = "None" // other options include "percent.mt,nFeature_RNA,S.Score,G2M.Score,nCount_RNA"
+    vars_to_regress             = null // other options include "percent.mt,nFeature_RNA,S.Score,G2M.Score,nCount_RNA"
 
     // seurat_preprocess.nf
     qc_filtering                = "miqc" //other options include "manual" (uses subsequent thresholds), "mads" (3 median absolute deviations)

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -60,8 +60,7 @@
           "description": "whether to run cellranger"
         },
         "vars_to_regress": {
-          "type": "string",
-          "default": "percent.mt,nFeature_RNA"
+          "type": "string"
         },
         "qc_filtering": {
           "type": "string",

--- a/workflows/gex.nf
+++ b/workflows/gex.nf
@@ -42,6 +42,9 @@ workflow GEX_EXQC {
         if (params.input)    { ch_input    = file(params.input)    } else { exit 1, 'Input samplesheet not specified!' }
         if (params.contrast) { ch_contrast = file(params.contrast) } else { exit 1, 'Contrast samplesheet not specified!' }
 
+        // if vars_to_regress is null, set it to 'NULL' for R to evaluate
+        def vars_to_regress = params.vars_to_regress ?: 'NULL'
+
         // Set output path to relative, species
         outdir_path = Channel.fromPath(params.outdir,relative:true)
         // Run Seurat for individual samples
@@ -88,7 +91,7 @@ workflow GEX_EXQC {
             ch_input,
             params.species,
             params.npcs,
-            params.vars_to_regress,
+            vars_to_regress,
             params.Rlib_dir,
             params.Rpkg,
             params.script_merge,
@@ -100,7 +103,7 @@ workflow GEX_EXQC {
             SEURAT_MERGE.out.rds,
             params.species,
             params.npcs,
-            params.vars_to_regress,
+            vars_to_regress,
             params.resolution_list,
             params.Rlib_dir,
             params.Rpkg,
@@ -113,7 +116,7 @@ workflow GEX_EXQC {
             SEURAT_MERGE.out.rds,
             params.species,
             params.npcs,
-            params.vars_to_regress,
+            vars_to_regress,
             params.resolution_list,
             params.Rlib_dir,
             params.Rpkg,
@@ -126,7 +129,7 @@ workflow GEX_EXQC {
             SEURAT_MERGE.out.rds,
             params.species,
             params.npcs,
-            params.vars_to_regress,
+            vars_to_regress,
             params.resolution_list,
             params.Rlib_dir,
             params.Rpkg,
@@ -140,7 +143,7 @@ workflow GEX_EXQC {
             SEURAT_MERGE.out.rds,
             params.species,
             params.npcs,
-            params.vars_to_regress,
+            vars_to_regress,
             params.resolution_list,
             params.conda_path,
             params.python_path,
@@ -156,7 +159,7 @@ workflow GEX_EXQC {
             SEURAT_MERGE.out.rds,
             params.species,
             params.npcs,
-            params.vars_to_regress,
+            vars_to_regress,
             params.resolution_list,
             params.Rlib_dir,
             params.Rpkg,


### PR DESCRIPTION
## Changes

- set `vars_to_regress` to `null` by default in `nextflow.config`
- improve logic in R code for handling when `vars_to_regress` is `null`,`NULL`,`"NULL"`, or an actual character vector.
  - note: `vars.to.regress` is `NULL` by default in [SCTransform](https://satijalab.org/seurat/reference/sctransform)

## Issues

NA

## PR Checklist

(~Strikethrough~ any points that are not applicable.)

- [x] This comment contains a description of changes with justifications, with any relevant issues linked.
- ~[ ] Write tests using [`nf-test`](https://www.nf-test.com/) for any new features, bug fixes, or other code changes.~
- [x] Update docs if there are any API changes.
- ~[ ] If a new nextflow process is implemented, define the process `container` and `stub`.~
- ~[ ] Update `CHANGELOG.md` with a short description of any user-facing changes and reference the PR number. Guidelines: https://keepachangelog.com/en/1.1.0/~ _will handle this in the main PR_
