### PR TITLE
fix: set --main to hidden & show nextflow options in help message

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,8 @@ jobs:
           sinclair init
           sinclair run \
             -stub \
-            -profile ci_stub,docker,test
+            -profile ci_stub,docker,test \
+            --mode local
       - name: "Upload Artifact"
         uses: actions/upload-artifact@v4
         if: always() # run even if previous steps fail

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## SINCLAIR development version
 
+- Improve help message for `sinclair run`. (#153, @kelly-sovacool)
+
 ## SINCLAIR 0.3.2
 
 - Improve error messages in SAMPLESHEET_CHECK processes. (#143, @kelly-sovacool)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## SINCLAIR development version
 
 - Improve help message for `sinclair run`. (#153, @kelly-sovacool)
+  - the default `--mode` is now `slurm`.
 
 ## SINCLAIR 0.3.2
 

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -55,17 +55,20 @@ def cli():
 
 help_msg_extra = """
 \b
+Nextflow options:
+-profile <profile>    Nextflow profile to use (e.g. test)
+-params-file <file>   Nextflow params file to use (e.g. assets/params.yml)
+-preview              Preview the processes that will run without executing them
+
+\b
 EXAMPLES:
 Execute with slurm:
-    sinclair run ... --mode slurm
+  sinclair run ... --mode slurm
 Preview the processes that will run:
-    sinclair run ... --mode local -preview
+  sinclair run ... --mode local -preview
 Add nextflow args (anything supported by `nextflow run`):
-    sinclair run ... -work-dir path/to/workDir
-Run with a specific installation of sinclair:
-    sinclair run --main path/to/sinclair/main.nf ...
-Run with a specific tag, branch, or commit from GitHub:
-    sinclair run --main CCBR/SINCLAIR -r v0.1.0 ...
+  sinclair run ... -profile test
+  sinclair run ... -profile test -params-file assets/params.yml
 """
 
 
@@ -84,6 +87,7 @@ Run with a specific tag, branch, or commit from GitHub:
     type=str,
     default=repo_base("main.nf"),
     show_default=True,
+    hidden=True,
 )
 @click.option(
     "--output",

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -101,7 +101,7 @@ Add nextflow args (anything supported by `nextflow run`):
     "_mode",
     help="Run mode (slurm, local)",
     type=str,
-    default="local",
+    default="slurm",
     show_default=True,
 )
 @click.option(

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -91,7 +91,7 @@ Add nextflow args (anything supported by `nextflow run`):
 )
 @click.option(
     "--output",
-    help="Output directory path for sinclair init & run. Equivalient to nextflow launchDir. Defaults to your current working directory.",
+    help="Output directory path for sinclair init & run. Be sure to run `sinclair init --output <output_dir>` before `sinclair run`. `--output` is equivalent to the nextflow launchDir. Defaults to your current working directory.",
     type=click.Path(file_okay=False, dir_okay=True, writable=True),
     default=pathlib.Path.cwd(),
     show_default=False,
@@ -117,6 +117,8 @@ Add nextflow args (anything supported by `nextflow run`):
 def run(main_path, output, _mode, force_all, **kwargs):
     """
     Run the workflow
+
+    Note: you must first run `sinclair init --output <output_dir>` to initialize the output directory.
 
     docs: https://ccbr.github.io/SINCLAIR
     """

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -63,12 +63,12 @@ Nextflow options:
 \b
 EXAMPLES:
 Execute with slurm:
-  sinclair run ... --mode slurm
+  sinclair run --output path/to/outdir --mode slurm
 Preview the processes that will run:
-  sinclair run ... --mode local -preview
+  sinclair run --output path/to/outdir --mode local -preview
 Add nextflow args (anything supported by `nextflow run`):
-  sinclair run ... --mode slurm -profile test
-  sinclair run ... --mode slurm -profile test -params-file assets/params.yml
+  sinclair run --output path/to/outdir --mode slurm -profile test
+  sinclair run --output path/to/outdir --mode slurm -profile test -params-file assets/params.yml
 """
 
 

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -67,8 +67,8 @@ Execute with slurm:
 Preview the processes that will run:
   sinclair run ... --mode local -preview
 Add nextflow args (anything supported by `nextflow run`):
-  sinclair run ... -profile test
-  sinclair run ... -profile test -params-file assets/params.yml
+  sinclair run ... --mode slurm -profile test
+  sinclair run ... --mode slurm -profile test -params-file assets/params.yml
 """
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -30,7 +30,7 @@ def test_citation():
 def test_preview():
     with tempfile.TemporaryDirectory() as tmp_dir:
         output = shell_run(
-            f"./bin/sinclair init --output {tmp_dir} && ./bin/sinclair run --output {tmp_dir} -preview"
+            f"./bin/sinclair init --output {tmp_dir} && ./bin/sinclair run --output {tmp_dir} --mode local -preview"
         )
     cmd_line = {
         l.split(":")[0].strip(): l.split(":")[1].strip()
@@ -42,7 +42,7 @@ def test_preview():
 
 def test_forceall():
     output = subprocess.run(
-        "./bin/sinclair run --forceall -preview -profile ci_stub",
+        "./bin/sinclair run --forceall -preview -profile ci_stub --mode local",
         capture_output=True,
         shell=True,
         text=True,
@@ -80,7 +80,7 @@ def test_run_no_init():
     with pytest.raises(Exception) as exc_info:
         with tempfile.TemporaryDirectory() as tmp_dir:
             output = shell_run(
-                f"./bin/sinclair run --output {tmp_dir}",
+                f"./bin/sinclair run --output {tmp_dir} --mode local",
                 check=True,
                 capture_output=True,
             )


### PR DESCRIPTION
## Changes

- set `--main` to hidden
- add nextflow options to help message
- clarify that `sinclair init` must be run before `sinclair run`
- set `--mode slurm` as default

## Issues

- fixes #151
- see also https://github.com/CCBR/CCBR_NextflowTemplate/issues/49

## PR Checklist

(~Strikethrough~ any points that are not applicable.)

- [x] This comment contains a description of changes with justifications, with any relevant issues linked.
- ~[ ] Write tests using [`nf-test`](https://www.nf-test.com/) for any new features, bug fixes, or other code changes.~
- [x] Update docs if there are any API changes.
- ~[ ] If a new nextflow process is implemented, define the process `container` and `stub`.~
- [x] Update `CHANGELOG.md` with a short description of any user-facing changes and reference the PR number. Guidelines: https://keepachangelog.com/en/1.1.0/
