### PR TITLE
feat: add save_cellranger_extra_files param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## SINCLAIR development version
 
+- New parameter `save_cellranger_extra_files` to control whether to save extra cellranger output files (bam, bai, cloupe) in addition to h5 files. Default is `false` to save space. (#195, @kelly-sovacool)
+
 ### Documentation updates
 
 - Major improvements to the docs website. (#160, @bianjh-cloud)

--- a/docs/params.md
+++ b/docs/params.md
@@ -15,22 +15,23 @@ Define where the pipeline should find input data and save output data.
 
 ## Main options
 
-| Parameter            | Description                                                                             | Type      | Default                   | Required | Hidden |
-| -------------------- | --------------------------------------------------------------------------------------- | --------- | ------------------------- | -------- | ------ |
-| `species`            |                                                                                         | `string`  | hg19                      |          |        |
-| `vars_to_regress`    |                                                                                         | `string`  |                           |          |        |
-| `qc_filtering`       |                                                                                         | `string`  | manual                    |          |        |
-| `nCount_RNA_max`     |                                                                                         | `integer` | 500000                    |          |        |
-| `nCount_RNA_min`     |                                                                                         | `integer` | 1000                      |          |        |
-| `nFeature_RNA_max`   |                                                                                         | `integer` | 5000                      |          |        |
-| `nFeature_RNA_min`   |                                                                                         | `integer` | 200                       |          |        |
-| `percent_mt_max`     |                                                                                         | `integer` | 10                        |          |        |
-| `percent_mt_min`     |                                                                                         | `integer` | 0                         |          |        |
-| `run_doublet_finder` |                                                                                         | `string`  | Y                         |          |        |
-| `seurat_resolution`  |                                                                                         | `string`  | 0.1,0.2,0.3,0.5,0.6,0.8,1 |          |        |
-| `npcs`               |                                                                                         | `integer` | 50                        |          |        |
-| `resolution_list`    |                                                                                         | `string`  | 0.1,0.2,0.3,0.5,0.6,0.8,1 |          |        |
-| `genome_dir`         | Path to the genome references. Overridden by platform configs, e.g. conf/biowulf.config | `string`  |                           |          |        |
+| Parameter                     | Description                                                                             | Type      | Default                   | Required | Hidden |
+| ----------------------------- | --------------------------------------------------------------------------------------- | --------- | ------------------------- | -------- | ------ |
+| `species`                     |                                                                                         | `string`  | hg19                      |          |        |
+| `vars_to_regress`             |                                                                                         | `string`  |                           |          |        |
+| `qc_filtering`                |                                                                                         | `string`  | manual                    |          |        |
+| `nCount_RNA_max`              |                                                                                         | `integer` | 500000                    |          |        |
+| `nCount_RNA_min`              |                                                                                         | `integer` | 1000                      |          |        |
+| `nFeature_RNA_max`            |                                                                                         | `integer` | 5000                      |          |        |
+| `nFeature_RNA_min`            |                                                                                         | `integer` | 200                       |          |        |
+| `percent_mt_max`              |                                                                                         | `integer` | 10                        |          |        |
+| `percent_mt_min`              |                                                                                         | `integer` | 0                         |          |        |
+| `run_doublet_finder`          |                                                                                         | `string`  | Y                         |          |        |
+| `seurat_resolution`           |                                                                                         | `string`  | 0.1,0.2,0.3,0.5,0.6,0.8,1 |          |        |
+| `npcs`                        |                                                                                         | `integer` | 50                        |          |        |
+| `resolution_list`             |                                                                                         | `string`  | 0.1,0.2,0.3,0.5,0.6,0.8,1 |          |        |
+| `save_cellranger_extra_files` | Whether to save extra cellranger files (bam, bai, cloupe) in addition to h5 files       | `boolean` | False                     |          |        |
+| `genome_dir`                  | Path to the genome references. Overridden by platform configs, e.g. conf/biowulf.config | `string`  |                           |          |        |
 
 ## Institutional config options
 

--- a/modules/local/cellranger_count_gex.nf
+++ b/modules/local/cellranger_count_gex.nf
@@ -5,15 +5,18 @@ process CELLRANGER_COUNT {
     input:
     tuple val(id), val(inDir)
     val(genome_dir)
-    val(run_cellranger)
+    val(save_cellranger_extra_files)
 
     output:
     tuple val(id), path('*/outs/filtered_feature_bc_matrix.h5'), emit: h5
-    //tuple val(id), path('*/outs/*.bam*'),                        emit: bam_bai
+    tuple val(id), path('*/outs/*.bam*'),                        emit: bam_bai, optional: true
+    tuple val(id), path('*/outs/*.cloupe'),                      emit: cloupe, optional: true
 
     script:
     def args = task.ext.args ?: ''
     def localmem = task.memory.toGiga()
+    // if not saving extra files, clean up bam, bai, & cloupe after run
+    def cleanup = save_cellranger_extra_files ? "" : "rm -rf $id/outs/*.bam* $id/outs/*.cloupe"
     """
     cellranger count \
         --id $id \
@@ -21,6 +24,7 @@ process CELLRANGER_COUNT {
         --transcriptome=${genome_dir} \
         --localcores=$task.cpus \
         --localmem=$localmem
+    ${cleanup}
     """
 
     stub:

--- a/nextflow.config
+++ b/nextflow.config
@@ -13,6 +13,7 @@ params {
     outdir                      = "${launchDir}/results"
     species                     = "hg38" // other options are "hg19", "GRCh38" (which is an alternate name for hg38), "mm10", "GRCm39"
     run_cellranger              = true
+    save_cellranger_extra_files = false // save only h5 (false) or also bam, bai, cloupe
     vars_to_regress             = null // other options include "percent.mt,nFeature_RNA,S.Score,G2M.Score,nCount_RNA"
 
     // seurat_preprocess.nf

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -106,6 +106,11 @@
           "type": "string",
           "default": "0.1,0.2,0.3,0.5,0.6,0.8,1"
         },
+        "save_cellranger_extra_files": {
+          "type": "boolean",
+          "description": "Whether to save extra cellranger files (bam, bai, cloupe) in addition to h5 files",
+          "default": false
+        },
         "genome_dir": {
           "type": "string",
           "format": "directory-path",

--- a/workflows/pre_process.nf
+++ b/workflows/pre_process.nf
@@ -60,7 +60,7 @@ workflow PREPROCESS_EXQC {
             CELLRANGER_COUNT (
                 ch_meta,
                 params.genome_dir,
-                params.run_cellranger
+                params.save_cellranger_extra_files
             )
             // [id, fastq input dir, h5 file]
             ch_fqdir_h5 = ch_meta.join(CELLRANGER_COUNT.out.h5)


### PR DESCRIPTION
## Changes

Add new parameter: `save_cellranger_extra_files`.
When false (default), only h5 files are published from cellranger_count.
When true, the bam, bai, & cloupe files are also published.

## Issues

resolves #187 

## PR Checklist

(~Strikethrough~ any points that are not applicable.)

- [x] This comment contains a description of changes with justifications, with any relevant issues linked.
- ~[ ] Write tests using [`nf-test`](https://www.nf-test.com/) for any new features, bug fixes, or other code changes.~
- [x] Update docs if there are any API changes.
- ~[ ] If a new nextflow process is implemented, define the process `container` and `stub`.~
- [x] Update `CHANGELOG.md` with a short description of any user-facing changes and reference the PR number. Guidelines: https://keepachangelog.com/en/1.1.0/
