### PR TITLE
feat: add largemem profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## SINCLAIR development version
 
+- New `largemem` profile for memory-intensive processes. (#196, @kelly-sovacool)
+
 ### Documentation updates
 
 - Major improvements to the docs website. (#160, @bianjh-cloud)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Fix samplesheet check to allow multi-digit sample IDs. (#189, @kelly-sovacool)
 
-
 ### Documentation updates
 
 - Major improvements to the docs website. (#160, @bianjh-cloud)

--- a/conf/base.config
+++ b/conf/base.config
@@ -28,9 +28,12 @@ process {
         time   = { check_max( 72.h                 , 'time'    ) }
     }
 
+    // this label is not used by any modules, but serves as an example of how to use the largemem queue if needed
     withLabel:process_largemem {
+        cpus   = { check_max( 48                   , 'cpus'    ) }
         memory = { check_max( 500.GB * task.attempt, 'memory' ) }
+        time   = { check_max( 72.h                 , 'time'    ) }
         queue = 'largemem'
         clusterOptions = ' --gres=lscratch:750 '
-    }
+     }
 }

--- a/conf/largmem.config
+++ b/conf/largmem.config
@@ -1,0 +1,11 @@
+process {
+
+    // use the largemem queue for process_high jobs
+    withLabel:process_high {
+        cpus   = { check_max( 48                   , 'cpus'    ) }
+        memory = { check_max( 500.GB * task.attempt, 'memory' ) }
+        time   = { check_max( 72.h                 , 'time'    ) }
+        queue = 'largemem'
+        clusterOptions = ' --gres=lscratch:750 '
+    }
+}

--- a/docs/user-guide/troubleshooting.md
+++ b/docs/user-guide/troubleshooting.md
@@ -31,18 +31,26 @@ Unlock the output directory, perform another dry-run, and check the status of th
 
 ```
 sinclair run \
-    -profile biowulf \
-    --input assets/input_manifest.csv \
-    --contrast assets/contrast_manifest.csv \
     --output /data/$USER/scRNA_test \
     -params-file assets/params.yml
 ```
 
 ## If a process runs out of resources
 
+You can run sinclair with the `largemem` profile to allocate more memory and use the `largemem` slurm partition for resource-intensive processes.
+
+```sh
+sinclair run \
+    -profile largemem \
+    --output /data/$USER/scRNA_test \
+    -params-file assets/params.yml
+```
+
+### Custom resources
+
 You can change the resources allocated to processes by changing them in `conf/base.config`.
 
-Here is an alternate version of the `process_high` label that allocates more resources and uses the `largemem` partition:
+Here is an alternate version of the `process_high` label that allocates more resources and uses the `largemem` slurm partition:
 
 ```
     withLabel:process_high {

--- a/nextflow.config
+++ b/nextflow.config
@@ -119,6 +119,7 @@ profiles {
     test_h5   { includeConfig 'conf/test_h5.config'   }
     test_pbmc { includeConfig 'conf/test_pbmc.config' } // contains files in khanlab
     debug { includeConfig 'conf/debug.config' }
+    largemem { includeConfig 'conf/largmem.config' }
 }
 
 includeConfig 'conf/modules.config'


### PR DESCRIPTION
## Changes

add `-profile largemem` so processes that use the process_high label will go to the largemem queue

### process_high with default profile

```
   withLabel:process_high {
      cpus = { check_max( 48                   , 'cpus'    ) }
      memory = { check_max( 250.GB * task.attempt, 'memory'  ) }
      time = { check_max( 72.h                 , 'time'    ) }
   }
```

### process_high with largemem profile

```
   withLabel:process_high {
      cpus = { check_max( 48                   , 'cpus'    ) }
      memory = { check_max( 500.GB * task.attempt, 'memory' ) }
      time = { check_max( 72.h                 , 'time'    ) }
      queue = 'largemem'
      clusterOptions = ' --gres=lscratch:750 '
   }
```

## test

you can see that this works as expected: 

```sh
nextflow config -profile test
nextflow config -profile test,largemem
```

## Issues

resolves #193 

## PR Checklist

(~Strikethrough~ any points that are not applicable.)

- [x] This comment contains a description of changes with justifications, with any relevant issues linked.
- ~[ ] Write tests using [`nf-test`](https://www.nf-test.com/) for any new features, bug fixes, or other code changes.~
- [x] Update docs if there are any API changes.
- ~[ ] If a new nextflow process is implemented, define the process `container` and `stub`.~
- [x] Update `CHANGELOG.md` with a short description of any user-facing changes and reference the PR number. Guidelines: https://keepachangelog.com/en/1.1.0/
