### PR TITLE
feat: fetch celldex references to working dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@
 - Re-ordering of batch correction report. (#174 @wong-nw)
 - Rename 'output' directory to 'results' for the nextflow workflow. (#186, @kelly-sovacool)
 
+### Bug fixes
+- Creates cache for celldex reference downloads in working directory (#203, @wong-nw)
+
 ## SINCLAIR 0.3.4
 
 - Improve error messages when checking the sample sheet and contrast sheet. (#181, #182, @kelly-sovacool)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 - All nextflow processes now use containers rather than environment modules for dependencies. (#95, @kelly-sovacool)
 
+### Bug fixes
+- Creates cache for celldex reference downloads in working directory (#203, @wong-nw)
+
+
 ## SINCLAIR 0.3.5
 
 - Fix samplesheet check to allow multi-digit sample IDs. (#189, @kelly-sovacool)
@@ -20,9 +24,6 @@
 
 - Re-ordering of batch correction report. (#174 @wong-nw)
 - Rename 'output' directory to 'results' for the nextflow workflow. (#186, @kelly-sovacool)
-
-### Bug fixes
-- Creates cache for celldex reference downloads in working directory (#203, @wong-nw)
 
 ## SINCLAIR 0.3.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@
 - All nextflow processes now use containers rather than environment modules for dependencies. (#95, @kelly-sovacool)
 
 ### Bug fixes
-- Creates cache for celldex reference downloads in working directory (#203, @wong-nw)
 
+- Creates cache for celldex reference downloads in working directory (#203, @wong-nw)
 
 ## SINCLAIR 0.3.5
 

--- a/bin/scRNA_functions.R
+++ b/bin/scRNA_functions.R
@@ -32,20 +32,20 @@ RUN_SINGLEr <- function(obj, refFile, fineORmain) {
 fetch_celldex_ref <- function(ref_name) {
   ref <- switch(ref_name,
     "hpca" = ,
-    "HumanPrimaryCellAtlasData" = fetchReference("hpca",version="2024-02-26", realize.assays = TRUE, cache = "./"),
+    "HumanPrimaryCellAtlasData" = celldex::fetchReference("hpca", version = "2024-02-26", realize.assays = TRUE, cache = "./"),
     "blueprint_encode" = ,
     "BP_encode" = ,
     "bpencode" = ,
-    "BlueprintEncodeData" = fetchReference("blueprint_encode", "2024-02-26", realize.assays = TRUE, cache = "./"),
+    "BlueprintEncodeData" = celldex::fetchReference("blueprint_encode", "2024-02-26", realize.assays = TRUE, cache = "./"),
     "monaco" = ,
-    "MonacoImmuneData" = fetchReference("monaco_immune", "2024-02-26", realize.assays = TRUE, cache = "./"),
+    "MonacoImmuneData" = celldex::fetchReference("monaco_immune", "2024-02-26", realize.assays = TRUE, cache = "./"),
     "immu_cell_exp" = ,
     "DatabaseImmuneCellExpressionData" = ,
-    "dice" = fetchReference("dice", "2024-02-26", realize.assays = TRUE, cache = "./"),
+    "dice" = celldex::fetchReference("dice", "2024-02-26", realize.assays = TRUE, cache = "./"),
     "immgen" = ,
-    "ImmGenData" = fetchReference("immgen", "2024-02-26", realize.assays = TRUE, cache = "./"),
+    "ImmGenData" = celldex::fetchReference("immgen", "2024-02-26", realize.assays = TRUE, cache = "./"),
     "mouseRNAseq" = ,
-    "MouseRNAseqData" = fetchReference("mouse_rnaseq", "2024-02-26", realize.assays = TRUE, cache = "./")
+    "MouseRNAseqData" = celldex::fetchReference("mouse_rnaseq", "2024-02-26", realize.assays = TRUE, cache = "./")
   )
   return(ref)
 }
@@ -129,7 +129,7 @@ RUN_SINGLEr_AVERAGE <- function(obj, refFile, fineORmain) {
   clustAnnot <- s$labels
   names(clustAnnot) <- colnames(avg)
   names(clustAnnot) <- gsub("SCT.", "", names(clustAnnot))
-  names(clustAnnot) <- gsub("^g","", names(clustAnnot))
+  names(clustAnnot) <- gsub("^g", "", names(clustAnnot))
 
   annotVect <- clustAnnot[match(obj$seurat_clusters, names(clustAnnot))]
   names(annotVect) <- colnames(obj)

--- a/bin/scRNA_functions.R
+++ b/bin/scRNA_functions.R
@@ -29,34 +29,49 @@ RUN_SINGLEr <- function(obj, refFile, fineORmain) {
   return(s$pruned.labels)
 }
 
+fetch_celldex_ref <- function(ref_name) {
+  ref <- switch(ref_name,
+    "hpca" = ,
+    "HumanPrimaryCellAtlasData" = fetchReference("hpca",version="2024-02-26", realize.assays = TRUE, cache = "./"),
+    "blueprint_encode" = ,
+    "BP_encode" = ,
+    "bpencode" = ,
+    "BlueprintEncodeData" = fetchReference("blueprint_encode", "2024-02-26", realize.assays = TRUE, cache = "./"),
+    "monaco" = ,
+    "MonacoImmuneData" = fetchReference("monaco_immune", "2024-02-26", realize.assays = TRUE, cache = "./"),
+    "immu_cell_exp" = ,
+    "DatabaseImmuneCellExpressionData" = ,
+    "dice" = fetchReference("dice", "2024-02-26", realize.assays = TRUE, cache = "./"),
+    "immgen" = ,
+    "ImmGenData" = fetchReference("immgen", "2024-02-26", realize.assays = TRUE, cache = "./"),
+    "mouseRNAseq" = ,
+    "MouseRNAseqData" = fetchReference("mouse_rnaseq", "2024-02-26", realize.assays = TRUE, cache = "./")
+  )
+  return(ref)
+}
 
 MAIN_SINGLER <- function(so_in, species, cache_path = NULL) {
-  if (dir.exists(cache_path)) {
-    gypsum::cacheDirectory(cache_path)
-  }
-  message(paste("gypsum cache dir:", gypsum::cacheDirectory()))
-
   if (species == "hg38" || species == "hg19") {
-    so_in$HPCA_main <- RUN_SINGLEr(so_in, celldex::HumanPrimaryCellAtlasData(), "label.main")
-    so_in$HPCA <- RUN_SINGLEr(so_in, celldex::HumanPrimaryCellAtlasData(), "label.fine")
-    so_in$BP_encode_main <- RUN_SINGLEr(so_in, celldex::BlueprintEncodeData(), "label.main")
-    so_in$BP_encode <- RUN_SINGLEr(so_in, celldex::BlueprintEncodeData(), "label.fine")
-    so_in$monaco_main <- RUN_SINGLEr(so_in, celldex::MonacoImmuneData(), "label.main")
-    so_in$monaco <- RUN_SINGLEr(so_in, celldex::MonacoImmuneData(), "label.fine")
+    so_in$HPCA_main <- RUN_SINGLEr(so_in, fetch_celldex_ref("hpca"), "label.main")
+    so_in$HPCA <- RUN_SINGLEr(so_in, fetch_celldex_ref("hpca"), "label.fine")
+    so_in$BP_encode_main <- RUN_SINGLEr(so_in, fetch_celldex_ref("BP_encode"), "label.main")
+    so_in$BP_encode <- RUN_SINGLEr(so_in, fetch_celldex_ref("BP_encode"), "label.fine")
+    so_in$monaco_main <- RUN_SINGLEr(so_in, fetch_celldex_ref("monaco"), "label.main")
+    so_in$monaco <- RUN_SINGLEr(so_in, fetch_celldex_ref("monaco"), "label.fine")
     so_in$immu_cell_exp_main <- RUN_SINGLEr(
-      so_in, celldex::DatabaseImmuneCellExpressionData(),
+      so_in, fetch_celldex_ref("dice"),
       "label.main"
     )
     so_in$immu_cell_exp <- RUN_SINGLEr(
-      so_in, celldex::DatabaseImmuneCellExpressionData(),
+      so_in, fetch_celldex_ref("dice"),
       "label.fine"
     )
     so_in$annot <- so_in$HPCA_main
   } else if (species == "mm10") {
-    so_in$immgen_main <- RUN_SINGLEr(so_in, celldex::ImmGenData(), "label.main")
-    so_in$immgen <- RUN_SINGLEr(so_in, celldex::ImmGenData(), "label.fine")
-    so_in$mouseRNAseq_main <- RUN_SINGLEr(so_in, celldex::MouseRNAseqData(), "label.main")
-    so_in$mouseRNAseq <- RUN_SINGLEr(so_in, celldex::MouseRNAseqData(), "label.fine")
+    so_in$immgen_main <- RUN_SINGLEr(so_in, fetch_celldex_ref("immgen"), "label.main")
+    so_in$immgen <- RUN_SINGLEr(so_in, fetch_celldex_ref("immgen"), "label.fine")
+    so_in$mouseRNAseq_main <- RUN_SINGLEr(so_in, fetch_celldex_ref("mouseRNAseq"), "label.main")
+    so_in$mouseRNAseq <- RUN_SINGLEr(so_in, fetch_celldex_ref("mouseRNAseq"), "label.fine")
     so_in$annot <- so_in$immgen_main
   }
   return(so_in)

--- a/bin/scRNA_functions.R
+++ b/bin/scRNA_functions.R
@@ -129,6 +129,7 @@ RUN_SINGLEr_AVERAGE <- function(obj, refFile, fineORmain) {
   clustAnnot <- s$labels
   names(clustAnnot) <- colnames(avg)
   names(clustAnnot) <- gsub("SCT.", "", names(clustAnnot))
+  names(clustAnnot) <- gsub("^g","", names(clustAnnot))
 
   annotVect <- clustAnnot[match(obj$seurat_clusters, names(clustAnnot))]
   names(annotVect) <- colnames(obj)
@@ -199,19 +200,19 @@ MAIN_BATCH_CORRECTION <- function(so_in, npcs, species, resolution_list, method_
   }
 
   if (species == "hg38" || species == "hg19") {
-    so$clustAnnot_HPCA_main <- RUN_SINGLEr_AVERAGE(so, celldex::HumanPrimaryCellAtlasData(), "label.main")
-    so$clustAnnot_HPCA <- RUN_SINGLEr_AVERAGE(so, celldex::HumanPrimaryCellAtlasData(), "label.fine")
-    so$clustAnnot_BP_encode_main <- RUN_SINGLEr_AVERAGE(so, celldex::BlueprintEncodeData(), "label.main")
-    so$clustAnnot_BP_encode <- RUN_SINGLEr_AVERAGE(so, celldex::BlueprintEncodeData(), "label.fine")
-    so$clustAnnot_monaco_main <- RUN_SINGLEr_AVERAGE(so, celldex::MonacoImmuneData(), "label.main")
-    so$clustAnnot_monaco <- RUN_SINGLEr_AVERAGE(so, celldex::MonacoImmuneData(), "label.fine")
-    so$clustAnnot_immu_cell_exp_main <- RUN_SINGLEr_AVERAGE(so, celldex::DatabaseImmuneCellExpressionData(), "label.main")
-    so$clustAnnot_immu_cell_exp <- RUN_SINGLEr_AVERAGE(so, celldex::DatabaseImmuneCellExpressionData(), "label.fine")
+    so$clustAnnot_HPCA_main <- RUN_SINGLEr_AVERAGE(so, fetch_celldex_ref("hpca"), "label.main")
+    so$clustAnnot_HPCA <- RUN_SINGLEr_AVERAGE(so, fetch_celldex_ref("hpca"), "label.fine")
+    so$clustAnnot_BP_encode_main <- RUN_SINGLEr_AVERAGE(so, fetch_celldex_ref("BP_encode"), "label.main")
+    so$clustAnnot_BP_encode <- RUN_SINGLEr_AVERAGE(so, fetch_celldex_ref("BP_encode"), "label.fine")
+    so$clustAnnot_monaco_main <- RUN_SINGLEr_AVERAGE(so, fetch_celldex_ref("monaco"), "label.main")
+    so$clustAnnot_monaco <- RUN_SINGLEr_AVERAGE(so, fetch_celldex_ref("monaco"), "label.fine")
+    so$clustAnnot_immu_cell_exp_main <- RUN_SINGLEr_AVERAGE(so, fetch_celldex_ref("dice"), "label.main")
+    so$clustAnnot_immu_cell_exp <- RUN_SINGLEr_AVERAGE(so, fetch_celldex_ref("dice"), "label.fine")
   } else if (species == "mm10") {
-    so$clustAnnot_immgen_main <- RUN_SINGLEr_AVERAGE(so, celldex::ImmGenData(), "label.main")
-    so$clustAnnot_immgen <- RUN_SINGLEr_AVERAGE(so, celldex::ImmGenData(), "label.fine")
-    so$clustAnnot_mouseRNAseq_main <- RUN_SINGLEr_AVERAGE(so, celldex::MouseRNAseqData(), "label.main")
-    so$clustAnnot_mouseRNAseq <- RUN_SINGLEr_AVERAGE(so, celldex::MouseRNAseqData(), "label.fine")
+    so$clustAnnot_immgen_main <- RUN_SINGLEr_AVERAGE(so, fetch_celldex_ref("immgen"), "label.main")
+    so$clustAnnot_immgen <- RUN_SINGLEr_AVERAGE(so, fetch_celldex_ref("immgen"), "label.fine")
+    so$clustAnnot_mouseRNAseq_main <- RUN_SINGLEr_AVERAGE(so, fetch_celldex_ref("mouseRNAseq"), "label.main")
+    so$clustAnnot_mouseRNAseq <- RUN_SINGLEr_AVERAGE(so, fetch_celldex_ref("mouseRNAseq"), "label.fine")
   }
   return(so)
 }


### PR DESCRIPTION
## Changes

<!--
Provide a summary of what is included in this Pull Request (PR).
-->

Following updates to `bin/scRNA_functions.R`

- Add a `fetch_celldex_ref` function to retrieve celldex references and store in cache that is set to current working directory.
- Updates `MAIN_SINGLEr` function to use `fetch_celldex_ref` function
- Updates `RUN_SINGLEr_AVERAGE` function to use `fetch_celldex_ref` function


## Issues

Fixes #199 
 
<!--
Reference any issues related to this PR.
If this PR fixes any issues, [use a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
when referring to the issue.
-->

## PR Checklist

(~Strikethrough~ any points that are not applicable.)

- [x] This comment contains a description of changes with justifications, with any relevant issues linked.
~- [ ] Write tests using [`nf-test`](https://www.nf-test.com/) for any new features, bug fixes, or other code changes.~
~- [ ] Update docs if there are any API changes.~
~- [ ] If a new nextflow process is implemented, define the process `container` and `stub`.~
- [x] Update `CHANGELOG.md` with a short description of any user-facing changes and reference the PR number. Guidelines: https://keepachangelog.com/en/1.1.0/
