### PR TITLE
fix: batch correction report to bypass bug in Seurat v5.3

### DIFF
--- a/bin/batch_correction_integration.Rmd
+++ b/bin/batch_correction_integration.Rmd
@@ -287,7 +287,12 @@ for (i in 1:length(objList)) {
       print("----Running harmony")
       dist <- dist(Embeddings(obj, reduction = "harmony")[, 1:npcs])
     } else if (objList[[i]] == "liger") {
-      dist <- dist(Embeddings(obj, reduction = "iNMF")[, 1:npcs])
+      print("----Running LIGER iNMF")
+      reduction_liger <- "iNMF"
+      if ("inmfNorm" %in% names(obj@reductions)){
+        reduction_liger <- "inmfNorm" 
+      }
+      dist <- dist(Embeddings(obj, reduction = reduction_liger)[, 1:npcs])
     } else {
       print("----Running PCA")
       dist <- dist(Embeddings(obj, reduction = "pca")[, 1:npcs])

--- a/bin/batch_correction_integration.Rmd
+++ b/bin/batch_correction_integration.Rmd
@@ -145,7 +145,7 @@ plot_list_annot <- list()
 for (i in 1:length(objList)) {
   obj <- OBJECT_SELECT(objList[i])
   title <- NAME_SELECT(objList[i])
-  sampleImage <- DimPlot(obj, group.by = "annot") +
+  sampleImage <- DimPlot(obj, group.by = annot) +
     ggtitle(title) +
     theme(legend.position = "bottom", legend.text = element_text(size = 12)) +
     guides(colour = guide_legend(ncol = 6, override.aes = list(size = 3)))
@@ -285,7 +285,7 @@ for (i in 1:length(objList)) {
   # Skip all calculations for objects greater than 90k cells
   if (ncol(obj) < 90000) {
     # if batch correction is harmony, use harmony reduction
-    # otherwise use PCA
+    # otherwise use PCA 
     if (length(grep("^harmony", objList[i]))) {
       print("----Running harmony")
       dist <- dist(Embeddings(obj, reduction = "harmony")[, 1:npcs])

--- a/bin/batch_correction_integration.Rmd
+++ b/bin/batch_correction_integration.Rmd
@@ -18,8 +18,6 @@ params:
   scviObj: "results/batch_correct/group1-group2_batch_correction_scvi.rds"
   ligerObj: "results/batch_correct/group1-group2_batch_correction_liger.rds"
   resolution_list: "0.1,0.2,0.3,0.5,0.6,0.8,1"
-  citeseq: "text"
-  annot: "text"
   npcs: 20
   scRNA_functions: "bin/scRNA_functions.R"
   testing: "Y"
@@ -39,8 +37,6 @@ ligerObj <- params$ligerObj
 resolution <- as.numeric(strsplit(params$resolution_list, ",")[[1]])
 npcs <- as.numeric(params$npcs)
 
-citeseq <- params$citeseq
-annot <- params$annot
 
 source(params$scRNA_functions)
 library(Seurat)
@@ -145,7 +141,8 @@ plot_list_annot <- list()
 for (i in 1:length(objList)) {
   obj <- OBJECT_SELECT(objList[i])
   title <- NAME_SELECT(objList[i])
-  sampleImage <- DimPlot(obj, group.by = annot) +
+  obj$annot[is.na(obj$annot)] <- "Undetermined"
+  sampleImage <- DimPlot(obj, group.by = "annot") +
     ggtitle(title) +
     theme(legend.position = "bottom", legend.text = element_text(size = 12)) +
     guides(colour = guide_legend(ncol = 6, override.aes = list(size = 3)))

--- a/bin/batch_correction_integration.Rmd
+++ b/bin/batch_correction_integration.Rmd
@@ -282,7 +282,7 @@ for (i in 1:length(objList)) {
   # Skip all calculations for objects greater than 90k cells
   if (ncol(obj) < 90000) {
     # if batch correction is harmony, use harmony reduction
-    # otherwise use PCA 
+    # otherwise use PCA
     if (length(grep("^harmony", objList[i]))) {
       print("----Running harmony")
       dist <- dist(Embeddings(obj, reduction = "harmony")[, 1:npcs])
@@ -290,7 +290,7 @@ for (i in 1:length(objList)) {
       print("----Running LIGER iNMF")
       reduction_liger <- "iNMF"
       if ("inmfNorm" %in% names(obj@reductions)){
-        reduction_liger <- "inmfNorm" 
+        reduction_liger <- "inmfNorm"
       }
       dist <- dist(Embeddings(obj, reduction = reduction_liger)[, 1:npcs])
     } else {

--- a/modules/local/batch_correction_integration.nf
+++ b/modules/local/batch_correction_integration.nf
@@ -32,8 +32,6 @@ process BATCH_CORRECT_INTEGRATION {
             ligerObj="$rds_l",
             npcs="$npcs",
             resolution_list="$resolution_list",
-            citeseq="",
-            annot="",
             scRNA_functions="$scRNA_functions",
             testing="N"),
         output_file = "${gid}_batch_correction_integration.html")'


### PR DESCRIPTION
## Changes
- Updates `batch_correction_integration.Rmd` to plot cell type annotations 
   - bypasses bug in Seurat v5.3 (fixed in v5.4) where DimPlot function calls on categories with NA values induce a cbind dimensional mismatch
- Updates `batch_correction_integration.Rmd and `batch_correction_integration.nf` to remove the unused `citeseq` and `annot` parameters in the initial function and workflow calls
- Updates `batch_correction_integration.Rmd` to catch for variation in `inmf` or `iNMF` dimensional reduction label as a result of updates to the `rliger` package 
<!--
Provide a summary of what is included in this Pull Request (PR).
-->

## Issues
Fixes #229
<!--
Reference any issues related to this PR.
If this PR fixes any issues, [use a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
when referring to the issue.
-->

## PR Checklist

(~Strikethrough~ any points that are not applicable.)

- [x] This comment contains a description of changes with justifications, with any relevant issues linked.
- ~[ ] Write tests using [`nf-test`](https://www.nf-test.com/) for any new features, bug fixes, or other code changes.~
- ~[ ] Update docs if there are any API changes.~
- ~[ ] If a new nextflow process is implemented, define the process `container` and `stub`.~
- ~[ ] Update `CHANGELOG.md` with a short description of any user-facing changes and reference the PR number. Guidelines: https://keepachangelog.com/en/1.1.0/~
